### PR TITLE
fix/NPE occur when require the token before initial job finish.

### DIFF
--- a/android/src/main/kotlin/za/co/britehouse/flutter_microsoft_authentication/FlutterMicrosoftAuthenticationPlugin.kt
+++ b/android/src/main/kotlin/za/co/britehouse/flutter_microsoft_authentication/FlutterMicrosoftAuthenticationPlugin.kt
@@ -67,7 +67,7 @@ class FlutterMicrosoftAuthenticationPlugin: MethodCallHandler {
       "acquireTokenSilently" -> acquireTokenSilently(scopes, authority, result)
       "loadAccount" -> loadAccount(result)
       "signOut" -> signOut(result)
-      "init" -> initPlugin(configPath)
+      "init" -> initPlugin(configPath, result)
       else -> result.notImplemented()
     }
 
@@ -103,11 +103,11 @@ class FlutterMicrosoftAuthenticationPlugin: MethodCallHandler {
     }
   }
 
-  private fun initPlugin(assetPath: String) {
-    createSingleAccountPublicClientApplication(assetPath)
+  private fun initPlugin(assetPath: String, result: Result) {
+    createSingleAccountPublicClientApplication(assetPath, result)
   }
 
-  private fun createSingleAccountPublicClientApplication(assetPath: String) {
+  private fun createSingleAccountPublicClientApplication(assetPath: String, result: Result) {
     val configFile = getConfigFile(assetPath)
     val context: Context = mainActivity.applicationContext
 
@@ -123,10 +123,12 @@ class FlutterMicrosoftAuthenticationPlugin: MethodCallHandler {
                  */
                 Log.d(TAG, "INITIALIZED")
                 mSingleAccountApp = application
+                result.success(null)
               }
 
               override fun onError(exception: MsalException) {
                 Log.e(TAG, exception.message)
+                result.error(exception.errorCode, exception.message, null)
               }
             })
   }

--- a/lib/flutter_microsoft_authentication.dart
+++ b/lib/flutter_microsoft_authentication.dart
@@ -9,6 +9,7 @@ class FlutterMicrosoftAuthentication {
   List<String> _kScopes;
   String _kClientID, _kAuthority;
   String _androidConfigAssetPath;
+  Future initialFuture;
 
   FlutterMicrosoftAuthentication(
       {String kClientID,
@@ -20,8 +21,22 @@ class FlutterMicrosoftAuthentication {
     _kScopes = kScopes;
     _androidConfigAssetPath = androidConfigAssetPath;
 
-    if (Platform.isAndroid)
-      _channel.invokeMethod("init", _createMethodcallArguments());
+    if (Platform.isAndroid) {
+      initialFuture = _channel.invokeMethod("init", _createMethodcallArguments());
+    }
+  }
+
+  /// Make sure the plugin has been ready.
+  ///
+  /// To prevent potential problem,
+  /// you should call this after instantiate [FlutterMicrosoftAuthentication].
+  ///
+  /// ``dart
+  /// final fma = FlutterMicrosoftAuthentication();
+  /// await fma.ensureInitialized();
+  /// ```
+  Future ensureInitialized () {
+    return Future.value(initialFuture);
   }
 
   Map<String, dynamic> _createMethodcallArguments() {


### PR DESCRIPTION
I found a NPE problem when I acquire token meanwhile `mSingleAccountApp` is null, because `init` hasn't been finished.

We should wait unit `init` is finished, then do other job.

In this pull request, I fix this problem.

And now you should:

```dart
final fma = FlutterMicrosoftAuthentication();
await fma.ensureInitialized();
```